### PR TITLE
mx6sabresd: Enable video interfaces in bootargs

### DIFF
--- a/include/configs/mx6sabre_common.h
+++ b/include/configs/mx6sabre_common.h
@@ -121,6 +121,14 @@
 #define EMMC_ENV ""
 #endif
 
+#ifndef VIDEO_ARGS
+#define VIDEO_ARGS ""
+#endif
+
+#ifndef VIDEO_ARGS_SCRIPT
+#define VIDEO_ARGS_SCRIPT ""
+#endif
+
 #define CONFIG_EXTRA_ENV_SETTINGS \
 	"script=boot.scr\0" \
 	"image=zImage\0" \
@@ -148,8 +156,22 @@
 			"fi; "	\
 		"fi\0" \
 	EMMC_ENV	  \
+	"video_args_hdmi=setenv video_args $video_args " \
+		"video=mxcfb${fb}:dev=hdmi,1280x720M@60,if=RGB24\0" \
+	"video_args_lvds=setenv video_args $video_args " \
+		"video=mxcfb${fb}:dev=ldb,LDB-XGA,if=RGB666\0" \
+	"video_args_lcd=setenv video_args $video_args " \
+		"video=mxcfb${fb}:dev=lcd,CLAA-WVGA,if=RGB666\0" \
+	"fb=0\0" \
+	"video_interfaces=hdmi lvds lcd\0" \
+	"video_args_script=" \
+		"for v in ${video_interfaces}; do " \
+			"run video_args_${v}; " \
+			"setexpr fb $fb + 1; " \
+		"done\0" \
 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
-		"root=${mmcroot}\0" \
+		"root=${mmcroot} " \
+		VIDEO_ARGS "\0" \
 	"loadbootscript=" \
 		"fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
 	"bootscript=echo Running bootscript from mmc ...; " \
@@ -157,6 +179,7 @@
 	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
 	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
 	"mmcboot=echo Booting from mmc ...; " \
+		VIDEO_ARGS_SCRIPT \
 		"run mmcargs; " \
 		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
 			"if run loadfdt; then " \

--- a/include/configs/mx6sabresd.h
+++ b/include/configs/mx6sabresd.h
@@ -31,6 +31,9 @@
 
 #define CONFIG_SUPPORT_EMMC_BOOT /* eMMC specific */
 
+#define VIDEO_ARGS        "${video_args}"
+#define VIDEO_ARGS_SCRIPT "run video_args_script; "
+
 #include "mx6sabre_common.h"
 
 #define CONFIG_SYS_FSL_USDHC_NUM	3


### PR DESCRIPTION
Generate kernel video bootargs for sabresd, based on a list of needed video
interfaces ("video_interfaces" U-Boot env-var). The order of initialization
and video settings can be fully customized.

Signed-off-by: Nikolay Dimitrov picmaster@mail.bg
