### PR TITLE
Fix address typo and add some helpful commands to the cgtqmx6eval readme

### DIFF
--- a/board/congatec/cgtqmx6eval/README
+++ b/board/congatec/cgtqmx6eval/README
@@ -23,6 +23,10 @@ This will generate the following binaries:
 Copy SPL and u-boot.img to the exported TFTP directory of the
 host PC (/tftpboot , for example).
 
+=> setenv ipaddr <ip of target board>
+
+=> setenv serverip <ip of tftp server>
+
 => sf probe
 
 => tftp 0x12000000 SPL

--- a/board/congatec/cgtqmx6eval/README
+++ b/board/congatec/cgtqmx6eval/README
@@ -29,7 +29,7 @@ host PC (/tftpboot , for example).
 
 => sf erase 0x0 0x10000
 
-=> sf write 0x12000000 0x400 0x100
+=> sf write 0x12000000 0x400 0x10000
 
 => tftp 0x12000000 u-boot.img
 


### PR DESCRIPTION
Following the current README command by command renders the module unbootable because we write data in the wrong location. This pull request fixes that.

Also I think it might be a good idea to include the commands for setting the target and server ips before attempting to tftp a new u-boot to the target.
