### PR TITLE
warp: Change default bootenv configuration

### DIFF
--- a/include/configs/warp.h
+++ b/include/configs/warp.h
@@ -107,7 +107,7 @@
 	"ip_dyn=yes\0" \
 	"mmcdev=0\0" \
 	"mmcpart=1\0" \
-	"mmcroot=/dev/mmcblk0p2 rootwait rw\0" \
+	"mmcroot=/dev/mmcblk1p2 rootwait rw\0" \
 	"dfu_alt_info=boot raw 0x2 0x400 mmcpart 1\0" \
 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
 		"root=${mmcroot}\0" \


### PR DESCRIPTION
Change default mmcroot to mmcblk1 in order to have a smooth boot process
with sdcard image built from meta-fsl-arm-extra.

Signed-off-by: Diego Rondini diego.rondini@kynetics.it
