### PR TITLE
fsl_qspi.c: Add operation delay to fix UBI access

### DIFF
--- a/drivers/spi/fsl_qspi.c
+++ b/drivers/spi/fsl_qspi.c
@@ -836,7 +836,7 @@ int qspi_xfer(struct fsl_qspi_priv *priv, unsigned int bitlen,
 	    (priv->cur_seqid == QSPI_CMD_BRWR))
 		qspi_ahb_invalid(priv);
 #endif
-
+	udelay(250);
 	return 0;
 }
 


### PR DESCRIPTION
UBI makes back to back accesses to the flash, before the controller
is ready. Add a 250 microsecond delay to fix this.

Signed-off-by: Kevin Paul Herbert <kph@platinasystems.com>