### PR TITLE
imx8m: introduce high speed mode support in usdhc

### DIFF
--- a/arch/arm/dts/fsl-imx8qm-mek-u-boot.dtsi
+++ b/arch/arm/dts/fsl-imx8qm-mek-u-boot.dtsi
@@ -118,8 +118,11 @@
 
 &usdhc1 {
 	u-boot,dm-spl;
+	u-boot,mmc-hs400-1_8v;
 };
 
 &usdhc2 {
 	u-boot,dm-spl;
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
 };

--- a/arch/arm/dts/fsl-imx8qxp-mek-u-boot.dtsi
+++ b/arch/arm/dts/fsl-imx8qxp-mek-u-boot.dtsi
@@ -118,8 +118,11 @@
 
 &usdhc1 {
 	u-boot,dm-spl;
+	u-boot,mmc-hs400-1_8v;
 };
 
 &usdhc2 {
 	u-boot,dm-spl;
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
 };

--- a/arch/arm/dts/imx8mm-beacon-kit-u-boot.dtsi
+++ b/arch/arm/dts/imx8mm-beacon-kit-u-boot.dtsi
@@ -37,6 +37,10 @@
 	/delete-property/ assigned-clock-rates;
 };
 
+&reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};
+
 &fec1 {
 	phy-reset-gpios = <&gpio4 22 GPIO_ACTIVE_LOW>;
 };

--- a/arch/arm/dts/imx8mm-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mm-evk-u-boot.dtsi
@@ -46,6 +46,10 @@
 	u-boot,dm-spl;
 };
 
+&reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};
+
 &pinctrl_reg_usdhc2_vmmc {
 	u-boot,dm-spl;
 };

--- a/arch/arm/dts/imx8mm-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mm-evk-u-boot.dtsi
@@ -100,10 +100,14 @@
 
 &usdhc2 {
 	u-boot,dm-spl;
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
 };
 
 &usdhc3 {
 	u-boot,dm-spl;
+	u-boot,mmc-hs400-1_8v;
+	u-boot,mmc-hs400-enhanced-strobe;
 };
 
 &i2c1 {

--- a/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
@@ -47,6 +47,10 @@
 	u-boot,dm-spl;
 };
 
+&reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};
+
 &pinctrl_uart2 {
 	u-boot,dm-spl;
 };

--- a/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
@@ -97,10 +97,14 @@
 
 &usdhc2 {
 	u-boot,dm-spl;
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
 };
 
 &usdhc3 {
 	u-boot,dm-spl;
+	u-boot,mmc-hs400-1_8v;
+	u-boot,mmc-hs400-enhanced-strobe;
 };
 
 &wdog1 {

--- a/arch/arm/dts/imx8mp-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mp-evk-u-boot.dtsi
@@ -49,6 +49,10 @@
 };
 
 &reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};
+
+&reg_usdhc2_vmmc {
 	u-boot,dm-spl;
 };
 

--- a/arch/arm/dts/imx8mp-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mp-evk-u-boot.dtsi
@@ -126,10 +126,14 @@
 
 &usdhc2 {
 	u-boot,dm-spl;
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
 };
 
 &usdhc3 {
 	u-boot,dm-spl;
+	u-boot,mmc-hs400-1_8v;
+	u-boot,mmc-hs400-enhanced-strobe;
 };
 
 &wdog1 {

--- a/arch/arm/dts/imx8mq-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mq-evk-u-boot.dtsi
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+&reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};

--- a/arch/arm/dts/imx8mq-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mq-evk-u-boot.dtsi
@@ -3,3 +3,12 @@
 &reg_usdhc2_vmmc {
 	u-boot,off-on-delay-us = <20000>;
 };
+
+&usdhc1 {
+	u-boot,mmc-hs400-1_8v;
+};
+
+&usdhc2 {
+	u-boot,sd-uhs-sdr104;
+	u-boot,sd-uhs-ddr50;
+};

--- a/arch/arm/dts/imx8mq-phanbell-u-boot.dtsi
+++ b/arch/arm/dts/imx8mq-phanbell-u-boot.dtsi
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+&reg_usdhc2_vmmc {
+	u-boot,off-on-delay-us = <20000>;
+};


### PR DESCRIPTION
This PR is targeted to address issues that can be observed with various sd cards connected to i.MX8M derivatives.

Current configuration of usdhc dts nodes for imx8m SOC derivatives does experience issues with recognition and mode switch for various sd card types from different manufacturers, sometimes leading to an abrupted boot process, either during attempt to load kernel image from attached media or failure to recognize the sd card when switch to higher speed mode is performed.

Modifications in patches introduced are aimed to resolve those issue by introducing a short delay when mode switch in attempted, and enabling high speed mode quirks for all imx8m derivatives.

Patch set is also submitted upstream:
http://patchwork.ozlabs.org/project/uboot/patch/20201202175910.11493-1-andrey.zhizhikin@leica-geosystems.com/
http://patchwork.ozlabs.org/project/uboot/patch/20201202180121.11550-1-andrey.zhizhikin@leica-geosystems.com/

-- andrey