### PR TITLE
[2022.01+fslc]: Patchset #1: imx8mn-ddr4-evk related additions

### DIFF
--- a/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mn-ddr4-evk-u-boot.dtsi
@@ -157,7 +157,9 @@
 	};
 
 
-	flash {
+	spl {
+		filename = "spl.bin";
+
 		mkimage {
 			args = "-n spl/u-boot-spl.cfgout -T imx8mimage -e 0x912000";
 
@@ -222,6 +224,21 @@
 					fdt = "fdt";
 				};
 			};
+		};
+	};
+
+	imx-boot {
+		filename = "flash.bin";
+		pad-byte = <0x00>;
+
+		spl: blob-ext@1 {
+			offset = <0x0>;
+			filename = "spl.bin";
+		};
+
+		uboot: blob-ext@2 {
+			offset = <0x58000>;
+			filename = "u-boot.itb";
 		};
 	};
 };

--- a/board/freescale/imx8mn_evk/imximage-8mn-ddr4.cfg
+++ b/board/freescale/imx8mn_evk/imximage-8mn-ddr4.cfg
@@ -7,4 +7,4 @@
 
 ROM_VERSION	v2
 BOOT_FROM	sd
-LOADER		mkimage.flash.mkimage	0x912000
+LOADER		u-boot-spl-ddr.bin	0x912000

--- a/doc/board/nxp/imx8mn_evk.rst
+++ b/doc/board/nxp/imx8mn_evk.rst
@@ -50,7 +50,6 @@ Burn the flash.bin to MicroSD card offset 32KB:
 .. code-block:: bash
 
    $sudo dd if=flash.bin of=/dev/sd[x] bs=1024 seek=32 conv=notrunc
-   $sudo dd if=u-boot.itb of=/dev/sd[x] bs=1024 seek=384 conv=notrunc
 
 Boot
 ----


### PR DESCRIPTION
This PR contains one patch to enable boot container generation for `imx8mn-ddr4-evk`, which was missed during `v2022.01` release cycle.

`Upstream-Status: Submitted` [[`https://lore.kernel.org/u-boot/20220117220407.769-1-andrey.zhizhikin@leica-geosystems.com/`](https://lore.kernel.org/u-boot/20220117220407.769-1-andrey.zhizhikin@leica-geosystems.com/)]