### PR TITLE
arm: dts: imx8mn-u-boot: use versioned ddr4 firmware

### DIFF
--- a/arch/arm/dts/imx8mn-u-boot.dtsi
+++ b/arch/arm/dts/imx8mn-u-boot.dtsi
@@ -85,7 +85,7 @@
 #ifdef CONFIG_IMX8M_LPDDR4
 			filename = "lpddr4_pmu_train_1d_imem.bin";
 #elif CONFIG_IMX8M_DDR4
-			filename = "ddr4_imem_1d.bin";
+			filename = "ddr4_imem_1d_201810.bin";
 #else
 			filename = "ddr3_imem_1d.bin";
 #endif
@@ -97,7 +97,7 @@
 #ifdef CONFIG_IMX8M_LPDDR4
 			filename = "lpddr4_pmu_train_1d_dmem.bin";
 #elif CONFIG_IMX8M_DDR4
-			filename = "ddr4_dmem_1d.bin";
+			filename = "ddr4_dmem_1d_201810.bin";
 #else
 			filename = "ddr3_dmem_1d.bin";
 #endif
@@ -109,7 +109,7 @@
 #ifdef CONFIG_IMX8M_LPDDR4
 			filename = "lpddr4_pmu_train_2d_imem.bin";
 #elif CONFIG_IMX8M_DDR4
-			filename = "ddr4_imem_2d.bin";
+			filename = "ddr4_imem_2d_201810.bin";
 #endif
 			type = "blob-ext";
 			align-end = <4>;
@@ -119,7 +119,7 @@
 #ifdef CONFIG_IMX8M_LPDDR4
 			filename = "lpddr4_pmu_train_2d_dmem.bin";
 #elif CONFIG_IMX8M_DDR4
-			filename = "ddr4_dmem_2d.bin";
+			filename = "ddr4_dmem_2d_201810.bin";
 #endif
 			type = "blob-ext";
 			align-end = <4>;


### PR DESCRIPTION
NXP tested imx8mn-ddr4 with firmware version 201810 only. Use this version for all imx8mn targets with DRAM DDR4.

Fixes: 93c4c0e4dd1 ("arm: dts: imx8mn-u-boot: Create common imx8mn-u-boot.dtsi")

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>