### PR TITLE
misc: imx: remove DM dependency for ocotp driver in SPL

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -348,7 +348,7 @@ config NPCM_HOST
 
 config SPL_MXC_OCOTP
 	bool "Enable MXC OCOTP driver in SPL"
-	depends on SPL_MISC && (ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_VF610)
+	depends on SPL_DRIVERS_MISC && (ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_VF610)
 	default y
 	help
 	  If you say Y here, you will get support for the One Time


### PR DESCRIPTION
The ocotp driver is available for regular and SPL builds using the (SPL_)MXC_OCOTP configuration. Also, the ocotp driver does not support the driver model (DM) configuration.

But, for SPL builds, the SPL_MXC_OCOTP configuration depends on SPL_MISC which implies on SPL_DM.

This commit replaces the dependency on SPL_MISC with SPL_DRIVERS_MISC. So the only requirement is to have enabled miscellaneous drivers for the SPL.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
