### PR TITLE
imx8mq-u-boot: Pass FIT offset to fix boot regression

### DIFF
--- a/arch/arm/dts/imx8mq-u-boot.dtsi
+++ b/arch/arm/dts/imx8mq-u-boot.dtsi
@@ -94,6 +94,8 @@
 #endif
 			#address-cells = <1>;
 
+			offset = <0x57c00>;
+
 			images {
 				uboot {
 					arch = "arm64";


### PR DESCRIPTION
Since commit 37e50627efac ("ARM: dts: imx: Convert i.MX8M flash.bin image generation to binman") the imx8mq-evk fails to boot:

U-Boot SPL 2024.10-rc4 (Sep 09 2024 - 16:08:22 -0300) PMIC:  PFUZE100 ID=0x10
SEC0:  RNG instantiated
Normal Boot
Trying to boot from MMC2

Fix it by passing the offset property for the FIT image, just like it is done on i.MX8MM.

Upstream-Status: Submitted [rpm5-devel@rpm5.org]

Fixes: 37e50627efac ("ARM: dts: imx: Convert i.MX8M flash.bin image generation to binman")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
